### PR TITLE
Add iPad and Linux as OSName and update DeviceOSVersion logic

### DIFF
--- a/src/svelte-system-info.ts
+++ b/src/svelte-system-info.ts
@@ -208,6 +208,7 @@
             VersionMatch = UserAgent.match(/Win(?:dows)?(?: Phone)?[\ _]?(?:(?:NT|9x) )?((?:(\d+\.)*\d+)|XP|ME|CE)\b/)
             if (VersionMatch && VersionMatch[1]) {
               switch (VersionMatch[1]) {
+                case '10.0':
                 case '6.4':  DeviceOSVersion = '10.0';        break
                 case '6.3':  DeviceOSVersion = '8.1';         break
                 case '6.2':  DeviceOSVersion = '8';           break
@@ -229,7 +230,7 @@
           VersionMatch = UserAgent.match(/OS ((\d+[._])+\d+) like Mac OS\ X/)
           break
         case 'Android':
-          VersionMatch = UserAgent.match(/(?:Android|Adr) ((\d+[._])+\d+)/)
+          VersionMatch = UserAgent.match(/(?:Android|Adr) ((\d+)[._]?\d*)/)
           break
         case 'ChromeOS':
           VersionMatch = UserAgent.match(/(?:CrOS) [^ ]+ ((\d+[._])+\d+)/)

--- a/src/svelte-system-info.ts
+++ b/src/svelte-system-info.ts
@@ -181,7 +181,7 @@
       DeviceOSName = 'BlackBerryOS'
     }
 
-    if (UserAgent.contains('Linux')) {
+    if (UserAgent.contains('Linux') && UserAgent.lacks('Android')) {
       DeviceOSName = 'Linux'
     }
 

--- a/src/svelte-system-info.ts
+++ b/src/svelte-system-info.ts
@@ -150,8 +150,12 @@
       DeviceOSName = 'macOS'
     }
 
-    if (UserAgent.contains('like Mac OS X')) {
+    if (UserAgent.contains('like Mac OS X') && UserAgent.contains('iPhone')) {
       DeviceOSName = 'iOS'
+    }
+
+    if (UserAgent.contains('like Mac OS X') && UserAgent.contains('iPad')) {
+      DeviceOSName = 'iPad'
     }
 
     if (
@@ -175,6 +179,10 @@
 
     if (UserAgent.contains('BlackBerry')) {
       DeviceOSName = 'BlackBerryOS'
+    }
+
+    if (UserAgent.contains('Linux')) {
+      DeviceOSName = 'Linux'
     }
 
   /**** DeviceOSVersion ****/
@@ -217,6 +225,7 @@
           VersionMatch = UserAgent.match(/OS X ((\d+[._])+\d+)\b/)
           break
         case 'iOS':
+        case 'iPad':
           VersionMatch = UserAgent.match(/OS ((\d+[._])+\d+) like Mac OS\ X/)
           break
         case 'Android':


### PR DESCRIPTION
Guten Tag!

I have added iPad and Linux as recognizable OSName. This fixes iPad being recognized as MacOS and Linux being recognized as (n/a). Linux doesn't have any version in the header that why I have not added it to the VersionName switch case.

Also updated the DeviceOSVersion logic to also recognize Android 12 and Windows 10 properly 

Example user agents 
```
Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148

Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.80 Safari/537.36

Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.80 Safari/537.36.

Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Mobile Safari/537.36 EdgA/97.0.1072.78
```